### PR TITLE
Fixed unexpected behaviour of returning an index less than the length…

### DIFF
--- a/replay.go
+++ b/replay.go
@@ -50,8 +50,10 @@ func IsSignatureBanned(signature string) bool {
 	defer bannedMutex.RUnlock()
 
 	for _, list := range bannedSignatures {
-		if sort.SearchStrings(list, signature) < len(list) {
-			return true
+		for _, entry := range list {
+			if entry == signature {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
Due to slice ordering, when using sort.SearchStrings the return result is based on the ordering of the existing list.
So the index returned could be less than len(list), depending on existing entries.

Replaced the check with a simple nested for loop to check for exact value instead of using sort.SearchStrings